### PR TITLE
Handle module names with a group

### DIFF
--- a/src/reporter.js
+++ b/src/reporter.js
@@ -25,7 +25,7 @@ module.exports = {
 
 		for (const moduleName in modules) {
 			if (modules.hasOwnProperty(moduleName)) {
-				const file = `${outputFolder}${prefix}${moduleName}.json`;
+				const file = `${outputFolder}${prefix}${moduleName.replace('/', '-')}.json`;
 				fs.writeFile(file, JSON.stringify(results, null, 4))
 			}
 		}


### PR DESCRIPTION
If the test is in a group, the module name is, e.g. `regression/dynamic-copy`, which fails when writing the file as the `/` is interpreted as a sub-dir

This just normalises `/` to `-`